### PR TITLE
Add `UseAutofac` extension method to configure Autofac in `ActorSystem`s

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Explicitly declare files that should always be converted to LF regardless of platform
+*.dotsettings text eol=lf

--- a/src/Akka.DI.AutoFac.sln.DotSettings
+++ b/src/Akka.DI.AutoFac.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofac/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akka.DI.AutoFac/ActorSystemExtensions.cs
+++ b/src/Akka.DI.AutoFac/ActorSystemExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Akka.DI.AutoFac;
+using Akka.DI.Core;
+using Autofac;
+
+// ReSharper disable once CheckNamespace
+namespace Akka.Actor
+{
+    /// <summary>
+    /// Extension methods for <see cref="ActorSystem"/> to configure Autofac
+    /// </summary>
+    public static class ActorSystemExtensions
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="AutoFacDependencyResolver"/> class
+        /// associated with the <see cref="ActorSystem"/>
+        /// </summary>
+        /// <param name="system">The actor system to plug into</param>
+        /// <param name="container">The container used to resolve references</param>
+        /// <exception cref="ArgumentNullException">
+        /// If the <paramref name="container"/> parameter is null.
+        /// </exception>
+        public static ActorSystem UseAutofac(this ActorSystem system, ILifetimeScope container)
+        {
+            UseAutofac(system, container, out _);
+            return system;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="AutoFacDependencyResolver"/> class
+        /// associated with the <see cref="ActorSystem"/>
+        /// </summary>
+        /// <param name="system">The actor system to plug into</param>
+        /// <param name="container">The container used to resolve references</param>
+        /// <param name="dependencyResolver">The Autofac dependency resolver instance created</param>
+        /// <exception cref="ArgumentNullException">
+        /// If the <paramref name="container"/> parameter is null.
+        /// </exception>
+        public static ActorSystem UseAutofac(this ActorSystem system, ILifetimeScope container, out IDependencyResolver dependencyResolver)
+        {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+
+            dependencyResolver = new AutoFacDependencyResolver(container, system);
+            return system;
+        }
+    }
+}


### PR DESCRIPTION
Currently, using dependency injection with [Akka.net](https://github.com/akkadotnet) and [Autofac](https://github.com/autofac) feels a little weird as all we do is create an instance of `AutoFacDependencyResolver` that "magically" wire things up for us.

```csharp
var propsResolver = new AutoFacDependencyResolver(container, system);
```

There's a couple of issues I see there:

**1**. It's not clear what's happening unless you read the source code of `AutoFacDependencyResolver` to understand that its constructor will associate the `container` with the `ActorSystem` and because of that, from that point on, you're good to go and use the `system.DI()` method

**2**. The instance of `AutoFacDependencyResolver` most likely will never be used by the developer (because we'll prob. use the `system.DI()` method), so creating a variable that doesn't get used at all, doesn't seem correct.

---

By using an extension method of `ActorSystem`, the relationship between the `ActorSystem` and the `container` becomes clear and we can immediately see that the `ActorSystem` is being _modified_ to use the `container` and that's why you're good to use the `system.DI()` method from that point on.

```csharp
system.UseAutofac(container);
```
 
We also no longer need to create the instance of `AutoFacDependencyResolver` ourselves and/or create a variable. For convenience, for the rare cases where we do need to use the `AutoFacDependencyResolver` instance created, we can use an overload of the `UseAutofac` extension method:

```
system.UseAutofac(container, out var propsResolver);
```